### PR TITLE
Fix the type declaration for the CHANNEL slot of class EXCHANGE.

### DIFF
--- a/src/exchange.lisp
+++ b/src/exchange.lisp
@@ -1,7 +1,7 @@
 (in-package :cl-bunny)
 
 (defclass exchange ()
-  ((channel :type channel
+  ((channel :type (or null channel)
             :initform nil
             :initarg :channel
             :reader exchange-channel)


### PR DESCRIPTION
The slot is initialized to NIL, but was defined to have type CHANNEL.